### PR TITLE
Add play.crystal-lang.org domain for carc.in. Also escape "." in domains in RegExp patterns which means "any character" for RegExp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ $ vicr https://gist.github.com/veelenga/a5b861ccd32ff559b7d2#file-benchmark_test
 # loads CarcIn file
 $ vicr https://carc.in/#/r/rlj
 
+# loads play.crystal-lang.org file
+$ vicr https://play.crystal-lang.org/#/r/rlj
+
 # loads raw file
 $ vicr http://example.com/program.cr
 ```

--- a/src/vicr/service/carc_in.cr
+++ b/src/vicr/service/carc_in.cr
@@ -2,8 +2,8 @@ module Vicr::Service::CarcIn
   extend self
 
   def raw(path : String)
-    if md = path.match /carc.in\/.*\/.*\/(.*)/
-      "https://carc.in/runs/#{md[1]}.cr"
+    if md = path.match /(carc\.in|play\.crystal-lang\.org)\/.*\/.*\/(.*)/
+      "https://carc.in/runs/#{md[2]}.cr"
     end
   end
 end

--- a/src/vicr/service/github.cr
+++ b/src/vicr/service/github.cr
@@ -6,7 +6,7 @@ module Vicr::Service::Github
   extend self
 
   def raw(path : String)
-    if md = path.match /github.com\/(.*)\/(.*)\/blob\/(.*)\/(.*)/
+    if md = path.match /github\.com\/(.*)\/(.*)\/blob\/(.*)\/(.*)/
       user, repo, branch, file = md[1], md[2], md[3], md[4]
       "https://raw.githubusercontent.com/#{user}/#{repo}/#{branch}/#{file}"
     end
@@ -14,7 +14,7 @@ module Vicr::Service::Github
 
   def gist_raw(path : String, language = nil : String)
     path, filename = path.split("#file-") + [nil]
-    if path && (md = path.match /gist.github.com\/.*\/(.*)/)
+    if path && (md = path.match /gist\.github\.com\/.*\/(.*)/)
       files = gist_files md[1]
       if filename
         files.map { |file| {url: file[:raw_url], dist: Levenshtein.distance file[:filename], filename} }


### PR DESCRIPTION
A small improvement to add `play.crystal-lang.org` domain.

Also includes a small fix that fixes dots in RegExps. E.g. if you write `http://carcxin/` or `http://carc/in` it will match `/carc.in/` RegExp since `.` means "any character" in RegExp. It needs to be escaped like `/carc\.in/`.
